### PR TITLE
less video desync

### DIFF
--- a/source/objects/VideoSprite.hx
+++ b/source/objects/VideoSprite.hx
@@ -131,7 +131,7 @@ class VideoSprite extends FlxSpriteGroup {
 		
 		super.update(elapsed);
 		
-		#if hxCodec
+		#if hxvlc
 		if (videoSprite != null && videoSprite.bitmap != null)
 		{
 			final expectedTime = videoSprite.bitmap.getPosition(); // get expected position

--- a/source/objects/VideoSprite.hx
+++ b/source/objects/VideoSprite.hx
@@ -128,7 +128,22 @@ class VideoSprite extends FlxSpriteGroup {
 				return;
 			}
 		}
+		
 		super.update(elapsed);
+		
+		#if hxCodec
+		if (videoSprite != null && videoSprite.bitmap != null)
+		{
+			final expectedTime = videoSprite.bitmap.getPosition(); // get expected position
+			final actualFrameTime = videoSprite.bitmap.currentTime; // current playback time (if available)
+
+			if (Math.abs(expectedTime - actualFrameTime) > 0.1) // 100ms threshold
+			{
+				trace('Video out of sync, correcting...');
+				videoSprite.bitmap.seek(expectedTime); // force seek to correct spot
+			}
+		}
+		#end
 	}
 
 	function set_canSkip(newValue:Bool)


### PR DESCRIPTION
alright, this essentially kinda makes them videos not have that big of a desync issue. and now instead of starting when there's still asset loading to do [leads to audio starting first and occasionally video being played off screen], it now waits for everything to load [either that or just both components of the video]